### PR TITLE
Include python_telegram_bot_django_persistence for persistence engine

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -3,3 +3,4 @@ psycopg2-binary>=2.8,<2.9
 requests~=2.25.1
 python-dotenv~=0.18.0
 python-telegram-bot~=13.7
+python-telegram-bot-django-persistence~=0.1.7

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/bot/engine.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/bot/engine.py
@@ -13,6 +13,7 @@ from telegram.ext import (
     ConversationHandler,
     Filters,
 )
+from python_telegram_bot_django_persistence.persistence import DjangoPersistence
 from django.conf import settings
 
 from . import commands, callbacks, conversation, constants, messages, models
@@ -62,7 +63,7 @@ class Bot(object):
 
         token = settings.TELEGRAM_TOKEN
 
-        self.updater = Updater(token=token, use_context=True, workers=200)
+        self.updater = Updater(token=token, use_context=True, workers=200, persistence=DjangoPersistence())
         self.bot = telegram.Bot(token=token)
 
         # Notify admins


### PR DESCRIPTION
I am an author of [python-telegram-bot-django-persistence](https://github.com/GamePad64/python-telegram-bot-django-persistence), and I think, that it would be beneficial to use it in your project template.

This package enables you to use Django ORM for persistent data storage, so your bot does not require any infrastructure, only DB, that you already have.